### PR TITLE
Patch to resolve WiFi Auth Mode and states

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ esphome:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 ```
 
 # Features

--- a/localbytes-plug-pm.yaml
+++ b/localbytes-plug-pm.yaml
@@ -28,7 +28,7 @@ api:
         actual_value: float
       then:
         - lambda: |-
-            id(voltage_multiply) = actual_value / id(voltage).raw_state;
+            id(voltage_multiply) = actual_value / id(voltage).get_raw_state();
         - number.set:
             id: voltage_factor
             value: !lambda "return id(voltage_multiply);"
@@ -38,7 +38,7 @@ api:
         actual_value: float
       then:
         - lambda: |-
-            id(power_multiply) = actual_value / id(power).raw_state;
+            id(power_multiply) = actual_value / id(power).get_raw_state();
         - number.set:
             id: power_factor
             value: !lambda "return id(power_multiply);"
@@ -48,7 +48,7 @@ api:
         actual_value: float
       then:
         - lambda: |-
-            id(current_multiply) = actual_value / id(current).raw_state;
+            id(current_multiply) = actual_value / id(current).get_raw_state();
         - number.set:
             id: current_factor
             value: !lambda "return id(current_multiply);"


### PR DESCRIPTION
WiFi Auth Mode is moving to WPA2 in 2026.6
raw_state' is deprecated: Use get_raw_state() instead of .raw_state. Will be removed in 2026.10.0